### PR TITLE
Add tappable links in task descriptions

### DIFF
--- a/TodoListMore/Utils/StringExtensions.swift
+++ b/TodoListMore/Utils/StringExtensions.swift
@@ -1,0 +1,39 @@
+//
+//  StringExtensions.swift
+//  TodoListMore
+//
+//  Created by Codex on 2023.
+//
+
+import Foundation
+import SwiftUI
+
+extension String {
+    /// Detect the first URL contained in the string
+    func firstURL() -> URL? {
+        guard let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue) else {
+            return nil
+        }
+        let range = NSRange(startIndex..., in: self)
+        return detector.matches(in: self, options: [], range: range)
+            .compactMap { $0.url }
+            .first
+    }
+
+    /// Return an `AttributedString` with URLs converted to tappable links.
+    func linkified() -> AttributedString {
+        var attributed = AttributedString(self)
+        guard let detector = try? NSDataDetector(
+            types: NSTextCheckingResult.CheckingType.link.rawValue
+        ) else { return attributed }
+
+        let nsRange = NSRange(startIndex..., in: self)
+        for match in detector.matches(in: self, options: [], range: nsRange) {
+            guard let url = match.url,
+                  let range = Range(match.range, in: self) else { continue }
+            attributed[range].link = url
+            attributed[range].foregroundColor = .blue
+        }
+        return attributed
+    }
+}

--- a/TodoListMore/Views/Tasks/Components/TaskCardView.swift
+++ b/TodoListMore/Views/Tasks/Components/TaskCardView.swift
@@ -215,13 +215,13 @@ struct TaskCardHeaderView: View {
         
         // Show a snippet of the description if available
         if !description.isEmpty {
-            Text(description)
+            Text(description.linkified())
                 .font(.system(size: 14))
-                .foregroundColor(.secondary)
-                .lineLimit(3) // Allow up to 3 lines for description
-                .padding(.vertical, 4) // Equal padding top and bottom
+                .lineLimit(3)
+                .padding(.vertical, 4)
                 .padding(.horizontal, 16)
-                .padding(.leading, 46) // Align with title text
+                .padding(.leading, 46)
+                .onOpenURL { UIApplication.shared.open($0) }
         }
     }
 }

--- a/TodoListMore/Views/Tasks/TaskDetailView.swift
+++ b/TodoListMore/Views/Tasks/TaskDetailView.swift
@@ -49,8 +49,8 @@ struct TaskDetailView: View {
             // Task description
             if let description = task.taskDescription, !description.isEmpty {
                 Section {
-                    Text(description)
-                        .foregroundColor(.primary)
+                    Text(description.linkified())
+                        .onOpenURL { UIApplication.shared.open($0) }
                 }
             }
             


### PR DESCRIPTION
## Summary
- detect URLs within text and provide a `linkified()` string helper
- render tappable links in `TaskCardView` and `TaskDetailView`

## Testing
- `swift --version`
- `xcodebuild -version` *(fails: command not found)*